### PR TITLE
DOC fix warning message in plot_narx_msa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.0
+        uses: pypa/cibuildwheel@v2.23.1
         env:
           CIBW_BUILD: cp3*-*
           CIBW_SKIP: pp* *i686* *musllinux* *-macosx_universal2 *-manylinux_ppc64le *-manylinux_s390x

--- a/examples/plot_narx_msa.py
+++ b/examples/plot_narx_msa.py
@@ -130,7 +130,7 @@ narx_model.fit(u_train, y_train)
 y_train_osa_pred = narx_model.predict(u_train, y_init=y_train[:max_delay])
 y_test_osa_pred = narx_model.predict(u_test, y_init=y_test[:max_delay])
 
-narx_model.fit(u_train, y_train, coef_init="one_step_ahead")
+narx_model.fit(u_train, y_train, coef_init="one_step_ahead", method="Nelder-Mead")
 y_train_msa_pred = narx_model.predict(u_train, y_init=y_train[:max_delay])
 y_test_msa_pred = narx_model.predict(u_test, y_init=y_test[:max_delay])
 
@@ -169,7 +169,7 @@ narx_model.fit(u_all, y_all)
 y_train_osa_pred = narx_model.predict(u_train, y_init=y_train[:max_delay])
 y_test_osa_pred = narx_model.predict(u_test, y_init=y_test[:max_delay])
 
-narx_model.fit(u_all, y_all, coef_init="one_step_ahead")
+narx_model.fit(u_all, y_all, coef_init="one_step_ahead", method="Nelder-Mead")
 y_train_msa_pred = narx_model.predict(u_train, y_init=y_train[:max_delay])
 y_test_msa_pred = narx_model.predict(u_test, y_init=y_test[:max_delay])
 

--- a/fastcan/narx.py
+++ b/fastcan/narx.py
@@ -420,11 +420,12 @@ class NARX(MultiOutputMixin, RegressorMixin, BaseEstimator):
             NARX whose coefficients and intercept are initialized by the array.
 
             .. note::
-                When coef_init is None, missing values (i.e., np.nan) are allowed.
+                When coef_init is `one_step_ahead`, the model will be trained as a
+                Multi-Step-Ahead NARX, rather than a One-Step-Ahead NARX.
 
         **params : dict
             Keyword arguments passed to
-            `scipy.optimize.least_squares`.
+            `scipy.optimize.minimize`.
 
         Returns
         -------

--- a/tests/test_narx.py
+++ b/tests/test_narx.py
@@ -254,26 +254,3 @@ def test_sample_weight():
     coef_ = narx.coef_
 
     assert np.any(coef_w != coef_)
-
-import numpy as np
-from fastcan.narx import NARX, print_narx
-rng = np.random.default_rng(12345)
-n_samples = 1000
-max_delay = 3
-e = rng.normal(0, 0.1, n_samples)
-u = rng.uniform(0, 1, n_samples+max_delay) # input
-y = np.zeros(n_samples+max_delay) # output
-for i in range(max_delay, n_samples+max_delay):
-    y[i] = 0.5*y[i-1] + 0.7*u[i-2] + 1.5*u[i-1]*u[i-3] + 1
-y = y[max_delay:]+e
-X = u[max_delay:].reshape(-1, 1)
-time_shift_ids = [[0, 1], # u(k-1)
-                  [0, 2], # u(k-2)
-                  [0, 3], # u(k-3)
-                  [1, 1]] # y(k-1)
-poly_ids = [[0, 2], # 1*u(k-1)
-            [0, 4], # 1*y(k-1)
-            [1, 3]] # u(k-1)*u(k-3)
-narx = NARX(time_shift_ids=time_shift_ids,
-            poly_ids=poly_ids).fit(X, y, coef_init="one_step_ahead")
-print_narx(narx)


### PR DESCRIPTION
## Checklist

- [x] Used a personal fork to propose changes
- [x] A reference to a related issue: #61 
- [x] A description of the changes

Specify Nelder-Mead method when coef_init="one_step_ahead". The method is slower, but gives better accuracy and no warning message.
