### PR TITLE
FEAT add time-narx to evaluate opt speed of narx fit

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3050,7 +3050,7 @@ packages:
 - pypi: .
   name: fastcan
   version: 0.3.2
-  sha256: 03075a84c4818be567d7a56dedb876efa71f811733d411f41bcb2c93163cfdf4
+  sha256: 91dc839be1251db991da3b261369f5f145a325c33fc7a7f2b08dc9f56cda574a
   requires_dist:
   - scikit-learn>=1.6.0
   - furo ; extra == 'docs'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ compilers = "*"
 time-h = "python -m timeit -n 5 -s 'import numpy as np; from fastcan import FastCan; X = np.random.rand(3000, 100); y = np.random.rand(3000, 20); s = FastCan(100, verbose=0).fit(X, y)'"
 time-eta = "python -m timeit -n 5 -s 'import numpy as np; from fastcan import FastCan; X = np.random.rand(3000, 100); y = np.random.rand(3000, 20); s = FastCan(100, eta=True, verbose=0).fit(X, y)'"
 profile-minibatch = { cmd = '''python -c "import cProfile; import numpy as np; from fastcan import minibatch; X = np.random.rand(100, 3000); y = np.random.rand(100, 20); cProfile.run('minibatch(X, y, 1000, 10, verbose=0)', sort='$SORT')"''', env = { SORT = "cumtime" } }
+time-narx = '''python -m timeit -n 1 -s "import numpy as np; from fastcan.narx import make_narx; rng = np.random.default_rng(5); X = rng.random((1000, 10)); y = rng.random((1000, 2)); s = make_narx(X, y, 10, max_delay=2, poly_degree=2, verbose=0).fit(X, y, coef_init='one_step_ahead', verbose=1)"'''
 
 [tool.pixi.feature.test.tasks]
 test = { cmd = "pytest", cwd = "tests" }


### PR DESCRIPTION
## Checklist

- [x] Used a personal fork to propose changes
- [x] A reference to a related issue: #59 
- [x] A description of the changes: add time-narx pixi task to evaluate optimisation speed of fitting of narx
