### PR TITLE
CI not cache in setup-pixi

### DIFF
--- a/.github/workflows/asv.yml
+++ b/.github/workflows/asv.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.9.0
         with:
           environments: dev
-          cache: true
+          cache: false
 
       - name: Run benchmarks
         shell: bash
@@ -42,7 +42,7 @@ jobs:
         with:
           name: asv-results-${{ matrix.os }}
           path: asv_benchmarks/results
-  
+
   publish-report:
     if: github.event_name == 'push' && github.event.repository.fork == false
     name: Build HTML report
@@ -71,7 +71,7 @@ jobs:
         with:
           ref: gh-pages
           path: gh-pages
-      
+
       - name: Copy previous results
         run: |
           mkdir -p asv_benchmarks/results
@@ -92,7 +92,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.9.0
         with:
           environments: dev
-          cache: true
+          cache: false
 
       - name: Generate HTML report
         run: pixi run asv-publish
@@ -106,8 +106,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: asv_benchmarks/html
           keep_files: true
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
+          user_name: "github-actions[bot]"
+          user_email: "github-actions[bot]@users.noreply.github.com"
           commit_message: ${{ github.event.head_commit.message }}
 
       - name: Upload artifact

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.9.0
         with:
           environments: static
-          cache: true
+          cache: false
 
       - name: Linter
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           environments: >-
             dev
             nogil
-          cache: true
+          cache: false
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.9.0
         with:
           environments: dev
-          cache: true
+          cache: false
       - name: Build SDist
         run: |
           pixi run build-sdist


### PR DESCRIPTION
## Checklist

- [x] Used a personal fork to propose changes
- [x] A reference to a related issue: #166 
- [x] A description of the changes
Do not cache the environment in setup-pixi to force pixi reinstall fastcan