### PR TITLE
PERF vectorize OLS scoring and batch projections

### DIFF
--- a/fastcan/utils.py
+++ b/fastcan/utils.py
@@ -107,21 +107,18 @@ def ols(X, y, t=1):
     scores = np.zeros(t, dtype=float)
 
     for i in range(t):
-        for j in range(n_features):
-            if not mask[j]:
-                r = w[:, j] @ v
-                r2[j] = r**2
+        r2[:] = (w.T @ v) ** 2
+        r2[mask] = 0
         d = np.argmax(r2)
         indices[i] = d
         scores[i] = r2[d]
         if i == t - 1:
             return indices, scores
         mask[d] = True
-        r2[d] = 0
-        for j in range(n_features):
-            if not mask[j]:
-                w[:, j] = w[:, j] - w[:, d] * (w[:, d] @ w[:, j])
-                w[:, j] /= np.linalg.norm(w[:, j], axis=0)
+        projections = w.T @ w[:, d]
+        for j in np.where(~mask)[0]:
+            w[:, j] -= w[:, d] * projections[j]
+            w[:, j] /= np.linalg.norm(w[:, j])
 
 
 @validate_params(


### PR DESCRIPTION
## Summary
- Vectorize scoring loop with `w.T @ v` (single BLAS call instead of per-column Python loop)
- Batch Gram-Schmidt projections with `w.T @ w[:, d]`, then per-column update
- Zero RAM increase — avoids fancy indexing copies by operating on full contiguous matrix

## Benchmark (end-to-end ols)

| Workload | OLD | NEW | Speedup | RAM diff |
|---|---|---|---|---|
| 500x200, select 20 | 69.1 ms | 37.4 ms | **1.8x** | **0%** |
| 1000x500, select 30 | 303.4 ms | 212.7 ms | **1.4x** | **0%** |

## Test plan
- [x] `pytest fastcan/tests/test_utils.py` — 4/4 pass
- [x] Full suite 101/101 pass