### PR TITLE
PERF vectorize tp2fd with masked numpy indexing

### DIFF
--- a/fastcan/narx/_feature.py
+++ b/fastcan/narx/_feature.py
@@ -666,9 +666,7 @@ def tp2fd(time_shift_ids, poly_ids):
     )
     feat_ids = np.full_like(_poly_ids, -1, dtype=int)
     delay_ids = np.full_like(_poly_ids, -1, dtype=int)
-    for i, poly_id in enumerate(_poly_ids):
-        for j, variable_id in enumerate(poly_id):
-            if variable_id != -1:
-                feat_ids[i, j] = _time_shift_ids[variable_id, 0]
-                delay_ids[i, j] = _time_shift_ids[variable_id, 1]
+    mask = _poly_ids != -1
+    feat_ids[mask] = _time_shift_ids[_poly_ids[mask], 0]
+    delay_ids[mask] = _time_shift_ids[_poly_ids[mask], 1]
     return feat_ids, delay_ids


### PR DESCRIPTION
## Summary
- Replace double for-loop in `tp2fd()` with boolean mask + advanced numpy indexing
- 3 lines instead of 5, idiomatic numpy

## Benchmark (end-to-end tp2fd)

| Workload | OLD | NEW | Speedup | RAM old | RAM new | RAM diff |
|---|---|---|---|---|---|---|
| 500 polys, degree 4 | 2.7 ms | 0.3 ms | **8.6x** | 50 KB | 86 KB | +35 KB (+70%) |
| 2000 polys, degree 5 | 12.5 ms | 1.0 ms | **12.9x** | 239 KB | 409 KB | +170 KB (+71%) |

RAM increase is from numpy temporaries for masked indexing. Absolute values are small (max +170 KB).

## Test plan
- [x] `pytest fastcan/narx/tests/test_narx.py` — 25/25 pass
- [x] Full suite 101/101 pass