### PR TITLE
CI remove uv as wasm wheel build frontend in cibw

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -12,7 +12,6 @@ jobs:
         uses: pypa/cibuildwheel@v4.1.0
         env:
           CIBW_PLATFORM: pyodide
-          CIBW_BUILD_FRONTEND: "build[uv]"
       - name: Upload package
         uses: actions/upload-artifact@v7
         with:

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'fastcan',
   'c', 'cython',
-  version: '0.6.0.dev0',
+  version: '0.7.0.dev0',
   license: 'MIT',
   meson_version: '>= 1.10.0',
   default_options: [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastcan"
-version = "0.6.0"
+version = "0.7.0.dev0"
 description = "A fast canonical-correlation-based search algorithm"
 authors = [
     { name = "Matthew Sikai Zhang", email = "matthew.szhang91@gmail.com" },


### PR DESCRIPTION
## Checklist

- [ ] Used a personal fork to propose changes
- [x] A reference to a related issue: #254 
- [x] A description of the changes: drop uv in build frontend in cibw for wasm wheel
