### PR TITLE
MNT remove git and asv from sdist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 # GitHub syntax highlighting
 pixi.lock linguist-language=YAML
 
+.* export-ignore
+asv_benchmarks export-ignore


### PR DESCRIPTION
## Checklist

- [ ] Used a personal fork to propose changes
- [x] A reference to a related issue: #267 
- [x] A description of the changes: remove .git, .github, asv, etc. from sdist according to [Meson Doc](https://mesonbuild.com/meson-python/how-to-guides/sdist.html)
